### PR TITLE
IDE-78 파일트리 파일 열기 구현

### DIFF
--- a/src/app/ide/FileTree/Node.tsx
+++ b/src/app/ide/FileTree/Node.tsx
@@ -5,7 +5,7 @@ import { MdEdit } from 'react-icons/md';
 import { RxCross2 } from 'react-icons/rx';
 import { FileDiv, NodeContainer } from './FileTree.styles';
 import { NodeData } from '@/types/IDE/FileTree/FileDataTypes';
-import React, { useState } from 'react';
+import React from 'react';
 import axiosInstance from '@/app/api/axiosInstance';
 import useCurrentOpenFile from '@/store/useCurrentOpenFile';
 import { findNowFilePath } from '@/utils/fileTreeUtils';
@@ -16,23 +16,22 @@ export const Node = ({
   dragHandle,
   tree,
 }: NodeRendererProps<NodeData>) => {
-  const [nowFilePath, setNowFilePath] = useState<string>('');
-
   const handleOpenFile = async () => {
     try {
-      setNowFilePath(findNowFilePath(node));
+      findNowFilePath(node);
+      const filePath = useCurrentOpenFile.getState().files;
       const { data } = await axiosInstance.post('/api/projects', {
         //여기에 현재 파일 경로 보내기
         //그리고 생성한 프로젝트 아이디 담아 보내기
-        name: { nowFilePath },
+        name: filePath,
         description: 'description',
         programmingLanguage: 'PYTHON',
         password: 'password',
       });
 
       //응답받은 filename, content 담아두기
-      useCurrentOpenFile.getState().setFiles(data.files);
-      useCurrentOpenFile.getState().setContent(data.content);
+      useCurrentOpenFile.getState().setContent(data.results.id);
+      //설정 후 렌더링 필요
 
       return data;
     } catch (error) {

--- a/src/store/useCurrentOpenFile.ts
+++ b/src/store/useCurrentOpenFile.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface CurrentOpenFileState {
+  directories: string | null;
+  files: string | null;
+  content: string | null;
+  setFiles: (filePath: string | null) => void;
+  setContent: (content: string | null) => void;
+}
+const useCurrentOpenFile = create<CurrentOpenFileState>(set => ({
+  directories: null,
+  files: null,
+  content: null,
+  setFiles: filePath => set({ files: filePath }),
+  setContent: newContent => set({ content: newContent }),
+}));
+
+export default useCurrentOpenFile;

--- a/src/utils/fileTreeUtils.ts
+++ b/src/utils/fileTreeUtils.ts
@@ -1,0 +1,14 @@
+import { NodeData } from '@/types/IDE/FileTree/FileDataTypes';
+import { NodeApi } from 'react-arborist';
+
+export const findNowFilePath = (node: NodeApi<NodeData> | null) => {
+  let filePath = '';
+  while (node!.data.id !== '__REACT_ARBORIST_INTERNAL_ROOT__') {
+    const newFile = '/' + node!.data.name;
+    filePath = newFile + filePath;
+    if (node) {
+      node = node.parent;
+    }
+  }
+  return filePath;
+};

--- a/src/utils/fileTreeUtils.ts
+++ b/src/utils/fileTreeUtils.ts
@@ -1,3 +1,4 @@
+import useCurrentOpenFile from '@/store/useCurrentOpenFile';
 import { NodeData } from '@/types/IDE/FileTree/FileDataTypes';
 import { NodeApi } from 'react-arborist';
 
@@ -10,5 +11,5 @@ export const findNowFilePath = (node: NodeApi<NodeData> | null) => {
       node = node.parent;
     }
   }
-  return filePath;
+  useCurrentOpenFile.getState().setFiles(filePath);
 };


### PR DESCRIPTION
## 변경내역

- 파일 클릭 시 서버 연결 설정(api 경로 수정 필요)
- 파일 클릭 시 해당 노드의 전체 파일 경로 찾는 함수 구현
- 현재 열려있는 파일 전역 상태 생성

## 특이사항

- 파일트리 서버가 없는 관계로 project 생성 서버로 임시 설정. 추후 수정 필요
  -> 해당 api의 반환 id값을 content로 임시 설정.
